### PR TITLE
Update docs for configure_tld

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -173,12 +173,12 @@ ${KEY_NAME}`.
 configuration. They contain any kind of configuration that is specific to a TLD,
 such as the create/renew price of a domain name, the pricing engine
 implementation, the DNS writer implementation, whether escrow exports are
-enabled, the default currency, the reserved label lists, and more. The `nomulus
-update_tld` command is used to set all of these options. See the
-[admin tool documentation](./admin-tool.md) for more information, as well as the
-command-line help for the `update_tld` command. Unlike global configuration
-above, per-TLD configuration options are stored as data in the running system,
-and thus do not require code pushes to update.
+enabled, the default currency, the reserved label lists, and more. The
+`configure_tld` command is used to set all of these options based on a YAML
+file. See the [admin tool documentation](./admin-tool.md) for more information,
+as well as the command-line help for the `configure_tld` command. Unlike global
+configuration above, per-TLD configuration options are stored as data in the
+running system, and thus do not require code pushes to update.
 
 [app-engine-config]: https://cloud.google.com/appengine/docs/java/configuration-files
 [default-config]: https://github.com/google/nomulus/blob/master/java/google/registry/config/files/default-config.yaml

--- a/docs/install.md
+++ b/docs/install.md
@@ -6,17 +6,16 @@ This document covers the steps necessary to download, build, and deploy Nomulus.
 
 You will need the following programs installed on your local machine:
 
-* A recent version of the [Java 11 JDK][java-jdk11].
-* [Google App Engine SDK for Java][app-engine-sdk], and configure aliases to the `gcloud` and `appcfg.sh` utilities (
-  you'll use them a lot).
+* [Java 21 JDK][java-jdk21].
+* [Google Cloud SDK](https://cloud.google.com/sdk/) for the `gcloud` command-line tool.
 * [Git](https://git-scm.com/) version control system.
 * Docker (confirm with `docker info` no permission issues, use `sudo groupadd docker` for sudoless docker).
 * Python version 3.7 or newer.
 * gnupg2 (e.g. in run `sudo apt install gnupg2` in Debian-like Linuxes)
 
-**Note:** App Engine does not yet support Java 9. Also, the instructions in this
-document have only been tested on Linux. They might work with some alterations
-on other operating systems.
+**Note:** Nomulus requires Java&nbsp;21. The instructions in this document have
+only been tested on Linux. They might work with some alterations on other
+operating systems.
 
 ## Download the codebase
 
@@ -131,8 +130,7 @@ files), you can rebuild and start using the `nomulus` tool to create test
 entities in your newly deployed system. See the [first steps tutorial](./first-steps-tutorial.md)
 for more information.
 
-[app-engine-sdk]: https://cloud.google.com/appengine/docs/java/download
-[java-jdk11]: https://www.oracle.com/java/technologies/javase-downloads.html 
+[java-jdk21]: https://www.oracle.com/java/technologies/javase/jdk21-downloads.html
 
 ## Deploy the BEAM Pipelines
 

--- a/docs/operational-procedures/premium-list-management.md
+++ b/docs/operational-procedures/premium-list-management.md
@@ -80,16 +80,15 @@ premium list must first be applied to a TLD before it will take effect. You will
 only need to do this when first creating a premium list; once it has been
 applied, it stays applied, and updates to the list are effective automatically.
 Note that each TLD can have no more than one premium list applied to it. To
-apply a premium list to a TLD, run the `update_tld` command with the following
-parameter:
+apply a premium list to a TLD, specify the list name in the `premiumListName`
+field of the TLD's YAML file and run `configure_tld`:
+
+```yaml
+premiumListName: exampletld
+```
 
 ```shell
-$ nomulus -e {ENVIRONMENT} update_tld exampletld --premium_list exampletld
-Update Registry@exampletld
-premiumList: null -> Key<?>(EntityGroupRoot("cross-tld")/PremiumList("exampletld"))
-
-Perform this command? (y/N): y
-Updated 1 entities.
+$ nomulus -e {ENVIRONMENT} configure_tld --input exampletld.yaml
 ```
 
 ## Checking which premium list is applied to a TLD

--- a/docs/operational-procedures/reserved-list-management.md
+++ b/docs/operational-procedures/reserved-list-management.md
@@ -127,16 +127,16 @@ reserved lists applied. The list of reserved labels for a TLD is the union of
 all applied reserved lists, using the precedence rules described earlier when a
 label appears in more than one list.
 
-To add a reserved list to a TLD, run the `update_tld` command with the following
-parameter:
+To add a reserved list to a TLD, include the list name in the
+`reservedListNames` field of the TLD's YAML file and run `configure_tld`:
+
+```yaml
+reservedListNames:
+- common_bad-words
+```
 
 ```shell
-$ nomulus -e {ENVIRONMENT} update_tld exampletld \
-    --add_reserved_lists common_bad-words
-Update Registry@exampletld
-reservedLists: null -> [Key<?>(EntityGroupRoot("cross-tld")/ReservedList("common_bad-words"))]
-Perform this command? (y/N): y
-Updated 1 entities.
+$ nomulus -e {ENVIRONMENT} configure_tld --input exampletld.yaml
 ```
 
 The `--add_reserved_lists` parameter can take a comma-delimited list of reserved

--- a/docs/operational-procedures/tld-security-restrictions.md
+++ b/docs/operational-procedures/tld-security-restrictions.md
@@ -21,22 +21,32 @@ webhosts.
 
 To configure allowed nameservers on a TLD, use the
 `--allowed_nameservers`, `--add_allowed_nameservers`, and
-`--remove_allowed_nameservers` parameters on the `update_tld` command as
-follows:
+`--remove_allowed_nameservers` fields in the TLD's YAML configuration and then
+run the `configure_tld` command as follows:
 
-```shell
-$ nomulus -e {ENVIRONMENT} update_tld --allowed_nameservers {NS1,NS2,...} {TLD}
+```yaml
+allowedFullyQualifiedHostNames:
+- ns1.example.test
+- ns2.example.test
 ```
 
-Note that `--allowed_nameservers` can also be used with the `create_tld` command
-when the TLD is initially created.
+```shell
+$ nomulus -e {ENVIRONMENT} configure_tld --input {TLD}.yaml
+```
+
+The same YAML fields should be used when the TLD is initially created.
 
 To set the allowed registrants, use the analogous `--allowed_registrants`,
 `--add_allowed_registrants`, and `--remove_allowed_registrants` parameters:
 
+```yaml
+allowedRegistrantContactIds:
+- CONTACTID1
+- CONTACTID2
+```
+
 ```shell
-$ nomulus -e {ENVIRONMENT} update_tld \
-    --allowed_registrants {CONTACTID1,CONTACTID2,...} {TLD}
+$ nomulus -e {ENVIRONMENT} configure_tld --input {TLD}.yaml
 ```
 
 When nameserver or registrant restrictions are set on a TLD, any domain mutation
@@ -78,12 +88,15 @@ of type `NAMESERVER_RESTRICTED`. Each domain will thus also need to have
 explicitly allowed nameservers configured in its reserved list entry, per the
 previous section.
 
-To apply domain create restriction when creating/updating a TLD, use the
-`--domain_create_restricted` parameter as follows:
+To apply domain create restriction when creating or updating a TLD, set the
+`domainCreateRestricted` field in the YAML and run `configure_tld`:
+
+```yaml
+domainCreateRestricted: true
+```
 
 ```shell
-$ nomulus -e {ENVIRONMENT} [create_tld | update_tld] \
-    --domain_create_restricted [true | false] {TLD}
+$ nomulus -e {ENVIRONMENT} configure_tld --input {TLD}.yaml
 ```
 
 Note that you do **not** have to set a TLD-wide allowed nameservers list with


### PR DESCRIPTION
## Summary
- replace old `create_tld` and `update_tld` references with YAML-based `configure_tld`
- show minimal YAML example in the first steps tutorial
- update reserved list, premium list and security docs
- describe per‑TLD configuration using the new command

## Testing
- `./nom_build runPresubmits` *(fails: No route to host while downloading gradle)*