### PR TITLE
Specify Google provider version

### DIFF
--- a/proxy/terraform/example_config.tf
+++ b/proxy/terraform/example_config.tf
@@ -12,6 +12,8 @@ module "proxy" {
   gcr_project_name         = "YOUR_GCR_PROJECT"
   proxy_domain_name        = "YOUR_PROXY_DOMAIN"
   proxy_certificate_bucket = "YOUR_CERTIFICATE_BUCKET"
+  proxy_certificate_bucket_location = "US"
+  bucket_uniform_access   = true
 
   # Uncomment to disable forwarding of whois HTTP interfaces.
   # public_web_whois         = 0

--- a/proxy/terraform/modules/gcs.tf
+++ b/proxy/terraform/modules/gcs.tf
@@ -1,6 +1,8 @@
 resource "google_storage_bucket" "proxy_certificate" {
   name          = var.proxy_certificate_bucket
   storage_class = "MULTI_REGIONAL"
+  location      = var.proxy_certificate_bucket_location
+  uniform_bucket_level_access = var.bucket_uniform_access
 }
 
 resource "google_storage_bucket_iam_member" "certificate_viewer" {

--- a/proxy/terraform/modules/gke/cluster.tf
+++ b/proxy/terraform/modules/gke/cluster.tf
@@ -33,8 +33,8 @@ resource "google_container_cluster" "proxy_cluster" {
     }
 
     management {
-      auto_repair  = "true"
-      auto_upgrade = "true"
+      auto_repair  = true
+      auto_upgrade = true
     }
   }
 }

--- a/proxy/terraform/modules/variables.tf
+++ b/proxy/terraform/modules/variables.tf
@@ -19,6 +19,18 @@ variable "proxy_certificate_bucket" {
     EOF
 }
 
+variable "proxy_certificate_bucket_location" {
+  type        = string
+  default     = "US"
+  description = "Location for the proxy certificate bucket"
+}
+
+variable "bucket_uniform_access" {
+  type        = bool
+  default     = true
+  description = "Whether uniform bucket-level access is enabled on the bucket"
+}
+
 variable "proxy_key_ring" {
   default     = "proxy-key-ring"
   description = "Cloud KMS keyring name"

--- a/proxy/terraform/versions.tf
+++ b/proxy/terraform/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.33"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add versions.tf to pin hashicorp/google provider to 6.33
- add location and uniform access options for proxy certificate bucket
- use booleans in GKE management block
- document new variables in example config

## Testing
- `./nom_build build` *(fails: No route to host when fetching gradle dependencies)*