### PR TITLE
Update Terraform modules for Google provider v6.33

### DIFF
--- a/proxy/terraform/example_config.tf
+++ b/proxy/terraform/example_config.tf
@@ -12,6 +12,8 @@ module "proxy" {
   gcr_project_name         = "YOUR_GCR_PROJECT"
   proxy_domain_name        = "YOUR_PROXY_DOMAIN"
   proxy_certificate_bucket = "YOUR_CERTIFICATE_BUCKET"
+  proxy_certificate_bucket_location = "US"
+  bucket_uniform_access              = true
 
   # Uncomment to disable forwarding of whois HTTP interfaces.
   # public_web_whois         = 0

--- a/proxy/terraform/modules/gcs.tf
+++ b/proxy/terraform/modules/gcs.tf
@@ -1,6 +1,8 @@
 resource "google_storage_bucket" "proxy_certificate" {
-  name          = var.proxy_certificate_bucket
-  storage_class = "MULTI_REGIONAL"
+  name                        = var.proxy_certificate_bucket
+  storage_class               = "MULTI_REGIONAL"
+  location                    = var.proxy_certificate_bucket_location
+  uniform_bucket_level_access = var.bucket_uniform_access
 }
 
 resource "google_storage_bucket_iam_member" "certificate_viewer" {

--- a/proxy/terraform/modules/gke/cluster.tf
+++ b/proxy/terraform/modules/gke/cluster.tf
@@ -33,8 +33,8 @@ resource "google_container_cluster" "proxy_cluster" {
     }
 
     management {
-      auto_repair  = "true"
-      auto_upgrade = "true"
+      auto_repair  = true
+      auto_upgrade = true
     }
   }
 }

--- a/proxy/terraform/modules/kms.tf
+++ b/proxy/terraform/modules/kms.tf
@@ -5,7 +5,7 @@ resource "google_kms_key_ring" "proxy_key_ring" {
 
 resource "google_kms_crypto_key" "proxy_key" {
   name     = var.proxy_key
-  key_ring = google_kms_key_ring.proxy_key_ring.self_link
+  key_ring = google_kms_key_ring.proxy_key_ring.id
 
   lifecycle {
     # If a crypto key gets destroyed, all data encrypted with it is lost.
@@ -14,7 +14,7 @@ resource "google_kms_crypto_key" "proxy_key" {
 }
 
 resource "google_kms_crypto_key_iam_member" "ssl_key_decrypter" {
-  crypto_key_id = google_kms_crypto_key.proxy_key.self_link
+  crypto_key_id = google_kms_crypto_key.proxy_key.id
   role          = "roles/cloudkms.cryptoKeyDecrypter"
   member        = "serviceAccount:${google_service_account.proxy_service_account.email}"
 }

--- a/proxy/terraform/modules/variables.tf
+++ b/proxy/terraform/modules/variables.tf
@@ -19,6 +19,18 @@ variable "proxy_certificate_bucket" {
     EOF
 }
 
+variable "proxy_certificate_bucket_location" {
+  description = "Location for the proxy certificate bucket"
+  type        = string
+  default     = "US"
+}
+
+variable "bucket_uniform_access" {
+  description = "Enable uniform bucket-level access on the certificate bucket"
+  type        = bool
+  default     = true
+}
+
 variable "proxy_key_ring" {
   default     = "proxy-key-ring"
   description = "Cloud KMS keyring name"

--- a/proxy/terraform/modules/versions.tf
+++ b/proxy/terraform/modules/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.33"
+    }
+  }
+}

--- a/proxy/terraform/versions.tf
+++ b/proxy/terraform/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.33"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add provider requirement to proxy module
- add location and uniform access options for the certificate bucket
- switch GKE cluster management flags to booleans
- use `id` for KMS resources
- document new variables in example config

## Testing
- `./nom_build build` *(fails: No route to host when downloading Gradle)*